### PR TITLE
fixed a wrong maximum SREC data length

### DIFF
--- a/srecord.h
+++ b/srecord.h
@@ -25,7 +25,7 @@ enum _SRecordDefinitions {
 	SRECORD_ADDRESS_OFFSET = 4,
 	SRECORD_CHECKSUM_LEN = 2,
 	/* Maximum ascii hex length of the S-Record data field */
-	SRECORD_MAX_DATA_LEN = 64,
+	SRECORD_MAX_DATA_LEN = 254*2,
 	/* Maximum ascii hex length of the S-Record address field */
 	SRECORD_MAX_ADDRESS_LEN = 8,
 	/* Ascii hex length of a single byte */


### PR DESCRIPTION
The "Data length" field is one byte, so the max value is 255. Excluding the one-byte checksum, the data string can be as long as 254 bytes = 508 (254*2) ASCII characters.
